### PR TITLE
Update leaflet.mouseCoordinate.js

### DIFF
--- a/src/leaflet.mouseCoordinate.js
+++ b/src/leaflet.mouseCoordinate.js
@@ -99,7 +99,7 @@ L.Control.mouseCoordinate  = L.Control.extend({
         }
         if(coord.lnggrad < 0){
             coord.lnggrad = coord.lnggrad * (-1);
-            coord.EW = "W";
+            coord.WE = "W";
         }
         return coord;
     },


### PR DESCRIPTION
Fixed typo that prevented coordinates from displaying W when cursor over Western hemisphere.